### PR TITLE
Changed from SamAccountName to UserPrincipalName

### DIFF
--- a/Disable-RemotePowerShell.ps1
+++ b/Disable-RemotePowerShell.ps1
@@ -2,23 +2,23 @@
 $AllowedGroup = "AllowRemotePowerShell"
 
 
-$AllUsers = get-mailbox -resultsize Unlimited | Get-User -ResultSize Unlimited | select SamAccountName,RemotePowerShellEnabled | where {$_.RemotePowerShellEnabled -eq $true}
-$AllowedUsers = Get-ADGroupMember $AllowedGroup -Recursive | ForEach-Object {Get-User -Identity $_.SamAccountName | select SamAccountName,RemotePowerShellEnabled}
+$AllUsers = Get-Mailbox -ResultSize Unlimited | Get-User -ResultSize Unlimited | Select UserPrincipalName, RemotePowerShellEnabled | Where {$_.RemotePowerShellEnabled -eq $true}
+$AllowedUsers = Get-ADGroupMember $AllowedGroup -Recursive | ForEach-Object {Get-User -Identity $_.SamAccountName | Select UserPrincipalName, RemotePowerShellEnabled}
 
 #Enable RemotePowerShell for allowed Users
 foreach ($AllowedUser in $AllowedUsers) {
 	if ($AllowedUser.RemotePowerShellEnabled -eq $False) {
-		Set-User $AllowedUser.SamAccountName -RemotePowerShellEnabled $true
+		Set-User $AllowedUser.UserPrincipalName -RemotePowerShellEnabled $true
 	}
 }
 
 #Disable RemotePowerShell for all Users
 foreach ($User in $AllUsers) {
-	if ($AllowedUsers.SamAccountName -notcontains $User.SamAccountName) {
-		Set-User $User.SamAccountName -RemotePowerShellEnabled $false
+	if ($AllowedUsers.UserPrincipalName -notcontains $User.UserPrincipalName) {
+		Set-User $User.UserPrincipalName -RemotePowerShellEnabled $false
 	}
 }
 
 #Display RemotePowerSthell State
-$RemotePowerShellState = get-mailbox -resultsize Unlimited | Get-User -ResultSize Unlimited | select SamAccountName,RemotePowerShellEnabled
+$RemotePowerShellState = Get-Mailbox -ResultSize Unlimited | Get-User -ResultSize Unlimited | Select UserPrincipalName, RemotePowerShellEnabled
 $RemotePowerShellState


### PR DESCRIPTION
Changed from SamAccountName to UserPrincipalName to avoid matching multiple entries, since I got
```
Set-User : The operation couldn't be performed because 'jobs' matches multiple entries.
At line:3 char:3
+         Set-User $User.SamAccountName -RemotePowerShellEnabled $false
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Set-User], ManagementObjectAmbiguousException
    + FullyQualifiedErrorId : [Server=EXMBF9104,RequestId=89eb20e1-f3d9-44b7-829d-a2f5aee4a00f,TimeStamp=10.10.2022 07:35:33] [FailureCategory=Cmdlet-ManagementObjectAmbiguousException] 4CCF0859,Microsoft.Exchange.Management. 
   RecipientTasks.SetUser
```
for SamAccountName jobs, jobsacademy, jobsmarketing, ...